### PR TITLE
Customize smart_open for bepress

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ setup(
     maintainer = u'Radim Řehůřek',
     maintainer_email = 'me@radimrehurek.com',
 
-    url = 'https://github.com/piskvorky/smart_open',
-    download_url = 'http://pypi.python.org/pypi/smart_open',
+    url = 'https://github.com/bepress/smart_open',
+    download_url = 'git+git://github.com/bepress/smart_open',
 
     keywords = 'file streaming, s3, hdfs',
 

--- a/smart_open/smart_open_lib.py
+++ b/smart_open/smart_open_lib.py
@@ -439,10 +439,7 @@ class S3OpenRead(object):
         self._open_reader()
 
     def _open_reader(self):
-        if is_gzip(self.read_key.name):
-            self.reader = gzipstreamfile.GzipStreamFile(self.read_key)
-        else:
-            self.reader = S3ReadStream(self.read_key)
+        self.reader = S3ReadStream(self.read_key)
 
     def __iter__(self):
         for line in self.reader:


### PR DESCRIPTION
We don't want to unzip files in order to read them line by line as
smart_open does. So, we're removing the checked for if a file is zipped
and treating all files the same for opens.

https://bepress.atlassian.net/browse/BP-4855